### PR TITLE
bump dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,11 +8,11 @@
         "laminas-api-tools"
     ],
     "require": {
-        "php": "^5.5 || ^7.0",
+        "php": "^7.3",
         "laminas/laminas-modulemanager": "^2.7",
-        "laminas/laminas-stdlib": "^2.7 || ^3.0",
+        "laminas/laminas-stdlib": "^3.0",
         "api-skeletons/oauth2-doctrine": "^4.0 || ^5.0",
-        "laminas/laminas-dependency-plugin": "^1.0"
+        "laminas/laminas-dependency-plugin": "^2.0"
     },
     "autoload": {
         "psr-4": {
@@ -23,8 +23,8 @@
         ]
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.8 || ^5.2",
-        "squizlabs/php_codesniffer": "^2.7",
-        "satooshi/php-coveralls": "~1.0"
+        "phpunit/phpunit": "^8.0 || ^9.0",
+        "squizlabs/php_codesniffer": "^2.7 || ^3.0",
+        "php-coveralls/php-coveralls": "^2.0"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,22 +1,11 @@
 <?xml version="1.0"?>
-<phpunit
-        bootstrap="./tests/Bootstrap.php"
-        colors="true"
-        convertErrorsToExceptions="true"
-        convertNoticesToExceptions="true"
-        convertWarningsToExceptions="true"
-        verbose="true"
-        stopOnFailure="false"
-        processIsolation="false"
-        backupGlobals="false"
-        syntaxCheck="true"
-        >
-    <testsuite name="LaminasApiOAuth2DoctrineMutateablename tests">
-        <directory>./tests</directory>
-    </testsuite>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./tests/Bootstrap.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" verbose="true" stopOnFailure="false" processIsolation="false" backupGlobals="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuite name="LaminasApiOAuth2DoctrineMutateablename tests">
+    <directory>./tests</directory>
+  </testsuite>
 </phpunit>

--- a/tests/src/Container/MutateTableNamesSubscriberFactoryTest.php
+++ b/tests/src/Container/MutateTableNamesSubscriberFactoryTest.php
@@ -6,17 +6,18 @@ use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use LaminasApi\OAuth2\Doctrine\MutateTableNames\Container\MutateTableNamesSubscriberFactory;
 use LaminasApi\OAuth2\Doctrine\MutateTableNames\EventSubscriber\MutateTableNamesSubscriber;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers  \LaminasApi\OAuth2\Doctrine\MutateTableNames\Container\MutateTableNamesSubscriberFactory
  */
-class MutateTableNamesSubscriberFactoryTest extends \PHPUnit_Framework_TestCase
+class MutateTableNamesSubscriberFactoryTest extends TestCase
 {
     public function testCanCreateFromFactory()
     {
         $container = $this->getMockBuilder(ContainerInterface::class)->getMock();
 
-        $container->expects($this->at(0))
+        $container
             ->method('get')
             ->with('config')
             ->willReturn([
@@ -28,7 +29,8 @@ class MutateTableNamesSubscriberFactoryTest extends \PHPUnit_Framework_TestCase
                         'default' => []
                     ]
                 ]
-            ]);
+            ])
+        ;
 
         $factory = new MutateTableNamesSubscriberFactory();
         $service = $factory($container, 'requestedname');
@@ -40,7 +42,7 @@ class MutateTableNamesSubscriberFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $container = $this->getMockBuilder(ServiceLocatorInterface::class)->getMock();
 
-        $container->expects($this->at(0))
+        $container
             ->method('get')
             ->with('config')
             ->willReturn([
@@ -64,7 +66,7 @@ class MutateTableNamesSubscriberFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $container = $this->getMockBuilder(ContainerInterface::class)->getMock();
 
-        $container->expects($this->at(0))
+        $container
             ->method('get')
             ->with('config')
             ->willReturn([

--- a/tests/src/ModuleTest.php
+++ b/tests/src/ModuleTest.php
@@ -12,11 +12,12 @@ use Laminas\Mvc\ApplicationInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use LaminasApi\OAuth2\Doctrine\MutateTableNames\EventSubscriber\MutateTableNamesSubscriber;
 use LaminasApi\OAuth2\Doctrine\MutateTableNames\Module;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers  \LaminasApi\OAuth2\Doctrine\MutateTableNames\Module
  */
-class ModuleTest extends \PHPUnit_Framework_TestCase
+class ModuleTest extends TestCase
 {
     public function testAttachesEventSubscriberToDoctrineEventManager()
     {
@@ -37,28 +38,21 @@ class ModuleTest extends \PHPUnit_Framework_TestCase
         $application->expects($this->once())->method('getServiceManager')->willReturn($serviceLocator);
 
         // get config from service manager mock
-        $serviceLocator->expects($this->at(0))
+        $serviceLocator
             ->method('get')
-            ->with('config')
-            ->willReturn([
-                'apiskeletons-oauth2-doctrine' => [
-                    'default' => [
-                        'event_manager' => 'event_manager_service_name'
+            ->withConsecutive(['config'], [MutateTableNamesSubscriber::class], ['event_manager_service_name'])
+            ->willReturnOnConsecutiveCalls(
+                [
+                    'apiskeletons-oauth2-doctrine' => [
+                        'default' => [
+                            'event_manager' => 'event_manager_service_name'
+                        ]
                     ]
-                ]
-            ]);
-
-        // get subscriber from service manager mock
-        $serviceLocator->expects($this->at(1))
-            ->method('get')
-            ->with(MutateTableNamesSubscriber::class)
-            ->willReturn($mutateTableNamesSubscriber);
-
-        // get doctrine event manager mock from service locatior
-        $serviceLocator->expects($this->at(2))
-            ->method('get')
-            ->with('event_manager_service_name')
-            ->willReturn($eventManager);
+                ],
+                $mutateTableNamesSubscriber,
+                $eventManager
+            )
+        ;
 
         // add subscriber to doctrine event manager
         $eventManager->expects($this->once())
@@ -75,7 +69,7 @@ class ModuleTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(AutoloaderProviderInterface::class, $module);
 
         $autoload = $module->getAutoloaderConfig();
-        $this->assertInternalType('array', $autoload);
+        $this->assertIsArray($autoload);
         $this->assertSame(array(
             'Laminas\\Loader\\StandardAutoloader' =>
                 array(
@@ -93,7 +87,7 @@ class ModuleTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(ConfigProviderInterface::class, $module);
 
-        $this->assertInternalType('array', $module->getConfig());
+        $this->assertIsArray($module->getConfig());
     }
 
     public function testModuleDependencies()

--- a/tests/src/Subscriber/MutateTableNamesSubscriberTest.php
+++ b/tests/src/Subscriber/MutateTableNamesSubscriberTest.php
@@ -4,18 +4,19 @@ namespace LaminasApi\OAuth2\Doctrine\MutateTableNamesTest;
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use LaminasApi\OAuth2\Doctrine\MutateTableNames\EventSubscriber\MutateTableNamesSubscriber;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers  \LaminasApi\OAuth2\Doctrine\MutateTableNames\EventSubscriber\MutateTableNamesSubscriber
  */
-class MutateTableNamesSubscriberTest extends \PHPUnit_Framework_TestCase
+class MutateTableNamesSubscriberTest extends TestCase
 {
     /**
      * @var MutateTableNamesSubscriber
      */
     private $subscriber;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->config     = include __DIR__ . '/../../../config/oauth2.doctrine-orm.mutatetablenames.global.php.dist';
         $this->config     = $this->config['apiskeletons-oauth2-doctrine']['mutatetablenames'];


### PR DESCRIPTION
Hi thanks for moving this package to laminas
In order to use this package, I need to update the dependencies

Change:
- Dropped support for versions prior to 7.3
- removed dependency to laminas/laminas-stdlib prior to version 3.0.0
- removed dependency to laminas/laminas-dependency-plugin prior to version 2.0.0
- upgraded Phpunit to version 8 or 9
- allow squizlabs/php_codesniffer version 3.0.0
- use "php-coveralls/php-coveralls" instead of "satooshi/php-coveralls" which is abandonned
- Upgraded the tests to comply to phpunit latest version